### PR TITLE
Make CSRFDefender work with Mojolicious 8

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Mojolicious::Plugin::CSRFDefender
 
+0.0.9    Fri Jul 19 12:28:33 UTC 2019
+        - Make it work under Mojolicious 8
+
 0.0.8    Sun May 26 22:36:54 2013
         - update tests for Mojolicious 4.0
 

--- a/lib/Mojolicious/Plugin/CSRFDefender.pm
+++ b/lib/Mojolicious/Plugin/CSRFDefender.pm
@@ -58,13 +58,13 @@ sub register {
     });
 
     # output filter
-    $app->hook(after_dispatch => sub {
-        my ($c) = @_;
+    $app->hook(after_render => sub {
+        my ($c, $content, $format) = @_;
         my $token = $self->_get_csrf_token($c);
         my $p_name = $self->parameter_name;
-        my $body = $c->res->body;
+        my $body = $$content;
         $body =~ s{(<form\s*[^>]*method=["']POST["'][^>]*>)}{$1\n<input type="hidden" name="$p_name" value="$token" />}isg;
-        $c->res->body($body);
+        $$content = $body;
     });
 
     return $self;

--- a/lib/Mojolicious/Plugin/CSRFDefender.pm
+++ b/lib/Mojolicious/Plugin/CSRFDefender.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '0.0.8';
+our $VERSION = '0.0.9';
 
 use base qw(Mojolicious::Plugin Class::Accessor::Fast);
 __PACKAGE__->mk_accessors(qw(


### PR DESCRIPTION
CSRFDefender 0.0.8 does not seem to work with Mojolicious 8.
This pull request make it work with Mojolicious 8 but I don't know if it hurts with older versions of Mojolicious.